### PR TITLE
Split historic vcenter releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,17 @@ Roadmap: There may be more than one table that hold the version information, e.g
 A merge operation will attempt to provide a unified table.
 
 ### Nested tables, merged columns/rows
-Roadmap: Tables may have nested tables (e.g. KB52520 - VCF).  
-A decomposition is needed to provide the information in a usable format. 
+Since v0.2.0: For vCenter build information (KB2143838), this release based on PR  #5 offers merged tables:
+The KB article contains three tables:
+- Release information for VCSA 7
+- Release information for VCSA/Windows VC 6.7
+- Release information for VCSA/Windows before that
+
+The merged output available is now:
+- one table for all VCSA releases
+- one table for all Windows releases
+- one table for all releases
+Unicode issues are addressed as well
 
 ## Output format and folder structures
 The way the output is currently structured is:   

--- a/data_handling.py
+++ b/data_handling.py
@@ -22,7 +22,7 @@ __deprecated__ = False
 __contact__ = "dominik@why-did-it.fail"
 __license__ = "GPLv3"
 __status__ = "beta"
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 import os
 

--- a/data_handling.py
+++ b/data_handling.py
@@ -49,8 +49,8 @@ def create_json_output(kb_dataobject, output_base_dir: str, record_type: str):
             table_id += 1
     if kb_dataobject.list_of_merged_frames:
         table_id = 0
-        for dataframe in kb_dataobject.list_of_merged_frames:
-            filename = f"kb{kb_dataobject.id}_{kb_dataobject.fmt_product}_merged{table_id}_release_as-{record_type}.json"
+        for table_name, dataframe in kb_dataobject.list_of_merged_frames.items():
+            filename = f"kb{kb_dataobject.id}_{kb_dataobject.fmt_product}_{table_name}_as-{record_type}.json"
             if "Build Number" in dataframe.columns and record_type == "index":
                 dataframe = transform_index(dataframe)
             try:
@@ -60,8 +60,6 @@ def create_json_output(kb_dataobject, output_base_dir: str, record_type: str):
                 )
             except ValueError as err:
                 print(f"{kb_dataobject.id}: Error for json {record_type} in merged table {table_id}: {err}")
-            finally:
-                table_id += 1
 
 
 def transform_index(dataframe):

--- a/kb_data.py
+++ b/kb_data.py
@@ -178,7 +178,7 @@ class Kb2143838(KbData):
     def merge_tables_kb2143838(self):
         """Accepts a list of dataframes, merge them and return a list of the merged df"""
         # Return this list when ready
-        merged_vcenter_tables = []
+        merged_vcenter_tables = {}
         # Prepare the tables
         vc7x_vcsa = self.list_of_dframes[0]
         vc67_vcsa = self.list_of_dframes[1]
@@ -188,15 +188,15 @@ class Kb2143838(KbData):
         # Merge VCSA tables
         merged_vcsa_builds = vc7x_vcsa.append(vc67_vcsa)
         merged_vcsa_builds.reset_index(drop=True, inplace=True)
-        merged_vcenter_tables.append(merged_vcsa_builds)
+        merged_vcenter_tables["vcsa_builds"] = merged_vcsa_builds
         # Merge vCenter for Windows tables
         merged_windows_builds = vc67_win.append(vc_le65)
         merged_windows_builds.reset_index(drop=True, inplace=True)
-        merged_vcenter_tables.append(merged_windows_builds)
+        merged_vcenter_tables["windows_vc_builds"] = merged_windows_builds
         # Merge both tables
         merged_vc_all_builds = merged_vcsa_builds.append(merged_windows_builds)
         merged_vc_all_builds.reset_index(drop=True, inplace=True)
-        merged_vcenter_tables.append(merged_vc_all_builds)
+        merged_vcenter_tables["all_vcenter_builds"] = merged_vc_all_builds
         # Return the list
         return merged_vcenter_tables
 

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ __deprecated__ = False
 __contact__ = "dominik@why-did-it.fail"
 __license__ = "GPLv3"
 __status__ = "beta"
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 # Imports
 from data_handling import create_json_output

--- a/templates/README.md
+++ b/templates/README.md
@@ -16,8 +16,18 @@ Columns may have more than one value, e.g. "Build Number - Version" in KB2143850
 In this case, two additional columns (Version, Build Number) will be added to the table each containing just a single Value.
 
 ### Merged tables
-Roadmap: There may be more than one table that hold the version information, e.g. in KB2143838 (vCenter Server).
-A merge operation will attempt to provide a unified table.
+Since v0.2.0: For vCenter build information (KB2143838), this release based on PR  #5 offers merged tables:
+The KB article contains three tables:
+- Release information for VCSA 7
+- Release information for VCSA/Windows VC 6.7
+- Release information for VCSA/Windows before that
+
+The merged output available is now:
+- one table for all VCSA releases
+- one table for all Windows releases
+- one table for all releases
+Unicode issues are addressed as well
+
 
 ### Nested tables, merged columns/rows
 Roadmap: Tables may have nested tables (e.g. KB52520 - VCF).  


### PR DESCRIPTION
Closing #6 by splitting up the release table for vCenter releases before 6.5
Also, improved naming for merged tables